### PR TITLE
Fix newlines

### DIFF
--- a/static/css/ordini_servizi_ge.css
+++ b/static/css/ordini_servizi_ge.css
@@ -545,11 +545,13 @@ body.sidebar-collapsed .main-content {
 }
 
 #gestione-gs-table {
-    min-width: 2000px;
+    /* permette alla tabella di ridimensionarsi in base al contenuto */
+    width: 100%;
+    min-width: 0;
 }
 
 #gestione-gs-table .tabulator-table {
-    font-size: 0.97rem;
+    font-size: 0.85rem;
     background: var(--surface, #fff);
     color: var(--text, #222);
 }
@@ -566,8 +568,9 @@ body.sidebar-collapsed .main-content {
     box-shadow: none;
 }
 #gestione-gs-table .tabulator-header .tabulator-col {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.85em;
+    padding: 0.35rem 0.6rem;
+    font-size: 0.9em;
+    text-transform: capitalize;
     border-right: 1px solid var(--accent-yellow, #BDD70F);
     background: transparent;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3,7 +3,7 @@
 /* Stile globale per il corpo del testo */
 body {
     font-family: 'Inter', 'Segoe UI', 'Roboto', 'Plus Jakarta Sans', Arial, sans-serif;
-    font-size: 0.4rem; /* 10px, ultra compatto */
+    font-size: 1rem; /* dimensione leggibile per il testo generico */
     padding-top: 70px; /* Altezza della navbar */
 }
 :root {

--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -16,6 +16,7 @@ console.log('ordini_servizi_ge.js caricato');
     let tabulatorTable = null;
     let columnsConfig = [];
     let editModeEnabled = false;
+    let currentParams = {};
 
     // Utility: mostra messaggi di errore
     function showError(msg) {
@@ -33,10 +34,10 @@ console.log('ordini_servizi_ge.js caricato');
                 title: col.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
                 field: col,
                 sorter: 'string',
-                editor: col === 'id' ? false : 'input',
+                editor: col.toLowerCase() === 'id' ? false : 'input',
                 visible: true,
                 headerSort: true,
-                cssClass: col === 'id' ? 'editable' : ''
+                cssClass: col.toLowerCase() === 'id' ? '' : 'editable'
             }));
         }
         // Altrimenti, rimuovi headerFilter come già fatto
@@ -48,10 +49,10 @@ console.log('ordini_servizi_ge.js caricato');
                 title: c.title || c.field.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
                 field: c.field,
                 sorter: 'string',
-                editor: c.field === 'id' ? false : 'input',
+                editor: c.field.toLowerCase() === 'id' ? false : 'input',
                 visible: true,
                 headerSort: true,
-                cssClass: c.field === 'id' ? 'editable' : ''
+                cssClass: c.field.toLowerCase() === 'id' ? '' : 'editable'
             };
         });
     }
@@ -127,6 +128,80 @@ console.log('ordini_servizi_ge.js caricato');
         }
     }
 
+    function getParams() {
+        const monthFilter = document.getElementById('month-filter');
+        const rtcFilter = document.getElementById('rtc-filter');
+        const searchInput = document.getElementById('generic-search');
+        return {
+            month_filter: monthFilter ? monthFilter.value : '',
+            rtc_filter: rtcFilter ? rtcFilter.value : '',
+            search: { value: searchInput ? searchInput.value : '' }
+        };
+    }
+
+    async function refreshRTCFilter(params) {
+        const rtcFilter = document.getElementById('rtc-filter');
+        if (!rtcFilter) return;
+        rtcFilter.disabled = true;
+        rtcFilter.innerHTML = '<option value="" selected>Seleziona RTC...</option>';
+        if (!params.month_filter) return;
+        try {
+            const payload = {
+                month_filter: params.month_filter,
+                search: { value: params.search ? params.search.value : '' },
+                columns: []
+            };
+            const response = await fetch('/api/servizi/ge/unique_values', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            let rtcValues = await response.json();
+            rtcValues = Array.from(new Set(rtcValues));
+            rtcValues.forEach(rtc => {
+                const opt = document.createElement('option');
+                opt.value = rtc;
+                opt.textContent = rtc;
+                rtcFilter.appendChild(opt);
+            });
+            if (rtcValues.length > 0) rtcFilter.disabled = false;
+        } catch (error) {
+            console.error('Errore nel caricamento dei valori RTC:', error);
+        }
+    }
+
+    async function loadOrUpdateTable() {
+        const params = getParams();
+        if (!params.month_filter) return; // richiede mese selezionato
+        currentParams = params;
+        if (!tabulatorTable) {
+            await initTabulator(params);
+        } else {
+            await tabulatorTable.setData('/api/servizi/ge/data', params);
+        }
+        refreshRTCFilter(params);
+    }
+
+    function setupEventListeners() {
+        const monthFilter = document.getElementById('month-filter');
+        const rtcFilter = document.getElementById('rtc-filter');
+        const searchInput = document.getElementById('generic-search');
+        if (monthFilter) {
+            monthFilter.addEventListener('change', loadOrUpdateTable);
+        }
+        if (rtcFilter) {
+            rtcFilter.disabled = true;
+            rtcFilter.addEventListener('change', loadOrUpdateTable);
+        }
+        if (searchInput) {
+            searchInput.addEventListener('keyup', function(e) {
+                if (e.key === 'Enter' || this.value === '') {
+                    loadOrUpdateTable();
+                }
+            });
+        }
+    }
+
     // Popola dinamicamente il select dei mesi
     async function populateMonthFilter() {
         const monthFilter = document.getElementById('month-filter');
@@ -154,7 +229,7 @@ console.log('ordini_servizi_ge.js caricato');
     }
 
     // Inizializza Tabulator
-    async function initTabulator() {
+    async function initTabulator(params) {
         try {
             columnsConfig = await fetchColumns();
         } catch (e) {
@@ -182,12 +257,7 @@ console.log('ordini_servizi_ge.js caricato');
         });
 
         // Parametri di ricerca/filtri
-        const monthFilter = document.getElementById('month-filter');
-        const rtcFilter = document.getElementById('rtc-filter');
-        const params = {
-            month_filter: monthFilter ? monthFilter.value : '',
-            rtc_filter: rtcFilter ? rtcFilter.value : ''
-        };
+        if (!params) params = getParams();
 
         tabulatorTable = new Tabulator('#gestione-gs-table', {
             ajaxURL: '/api/servizi/ge/data',
@@ -198,7 +268,7 @@ console.log('ordini_servizi_ge.js caricato');
                 // Adatta la risposta del backend (DataTables) al formato Tabulator
                 return response.data || [];
             },
-            layout: 'fitColumns',
+            layout: 'fitDataTable',
             responsiveLayout: false,
             columns: columnsConfig,
             columnDefaults: { headerFilter: false },
@@ -240,9 +310,12 @@ console.log('ordini_servizi_ge.js caricato');
                 col.updateDefinition({ headerFilter: false });
             });
             tabulatorTable.redraw(true);
-            // Log di debug per vedere la definizione delle colonne
             console.log('DEBUG: Colonne Tabulator dopo patch headerFilter:', tabulatorTable.getColumnDefinitions());
         }, 100);
+
+        tabulatorTable.on('dataLoaded', function () {
+            refreshRTCFilter(currentParams);
+        });
 
         // Setup esportazione
         setupExportButtons(tabulatorTable);
@@ -264,8 +337,7 @@ console.log('ordini_servizi_ge.js caricato');
             }
             console.log('Chiamo populateMonthFilter()');
             populateMonthFilter().then(() => {
-                console.log('populateMonthFilter() completata, ora chiamo initTabulator()');
-                initTabulator();
+                setupEventListeners();
             });
         } else {
             console.log('Tabella gestione-gs-table NON trovata, script non inizializzato');


### PR DESCRIPTION
## Summary
- fix `id` column case handling in `ordini_servizi_ge.js`
- apply `editable` class only to editable fields
- adjust table fonts and layout for readability
- delay Gestione GS table load until month is selected; refresh RTC select after every search or month change
- fix newline endings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856b3b81e50832382e6a785d4820a86