### PR TITLE
Implement row selection styling for Gestione GS table

### DIFF
--- a/static/css/ordini_servizi_ge.css
+++ b/static/css/ordini_servizi_ge.css
@@ -499,10 +499,9 @@ body.sidebar-collapsed .main-content {
 }
 
 /* Stile per le righe selezionate */
-/* Rimosso: .table-row-selected {
-    background-color: #d0e9fa !important; 
-    Un blu chiaro 
-} */
+.table-row-selected {
+    background-color: #d0e9fa !important; /* un blu chiaro */
+}
 
 /* Label DataTables sopra il select "Visualizza elementi" */
 #dt-length-container .dataTables_length label {

--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -294,8 +294,14 @@ console.log('ordini_servizi_ge.js caricato');
             rowClick: function (e, row) {
                 row.toggleSelect();
             },
-            rowSelected: function (row) {},
-            rowDeselected: function (row) {},
+            rowSelected: function (row) {
+                const el = row.getElement();
+                if (el) el.classList.add('table-row-selected');
+            },
+            rowDeselected: function (row) {
+                const el = row.getElement();
+                if (el) el.classList.remove('table-row-selected');
+            },
             tableBuilt: function() {
                 // Forza la rimozione dei filtri header
                 this.getColumns().forEach(col => {


### PR DESCRIPTION
## Summary
- restore styling rules for selected rows
- highlight rows when Tabulator selection changes

## Testing
- `pytest -q` *(fails: numpy dtype size changed / httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856d05895388323811de17ebaea42db