### PR TITLE
Fix edit toggle handling in Tabulator table

### DIFF
--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -108,6 +108,11 @@ console.log('ordini_servizi_ge.js caricato');
         if (!toggle) return;
         toggle.addEventListener('change', function () {
             editModeEnabled = this.checked;
+            table.getColumns().forEach(col => {
+                const def = col.getDefinition();
+                const canEdit = def.editor !== false && def.editor !== undefined;
+                col.updateDefinition({ editable: editModeEnabled && canEdit });
+            });
             table.setOptions({
                 cellEdited: editModeEnabled ? onCellEdit : null
             });


### PR DESCRIPTION
## Summary
- toggle all columns editable state based on checkbox in ordini_servizi_ge.js

## Testing
- `pytest -q` *(fails: numpy dtype size changed; httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856d0580f38832397eae6b57ad2532e