### PR TITLE
Fix month-filter dropdown direction

### DIFF
--- a/static/css/ordini_servizi_ge.css
+++ b/static/css/ordini_servizi_ge.css
@@ -15,6 +15,13 @@
     max-width: 180px;
 }
 
+/* Ensure custom select components always drop down */
+.bootstrap-select[data-dropup-auto="false"].dropup .dropdown-menu {
+    top: 100% !important;
+    bottom: auto !important;
+    transform: translateY(0) !important;
+}
+
 .nav-tabs#serviziTab .nav-link:hover {
     color: var(--accent) !important;
 }

--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -222,6 +222,9 @@ console.log('ordini_servizi_ge.js caricato');
                 monthFilter.appendChild(opt);
             });
             console.log('Select mesi popolato con', months.length, 'opzioni');
+            if (window.jQuery && jQuery.fn.selectpicker) {
+                jQuery('#month-filter').selectpicker({ dropupAuto: false });
+            }
         } catch (e) {
             showError('Impossibile caricare i mesi: ' + e.message);
             console.error('Errore durante il popolamento dei mesi:', e);

--- a/templates/ordini_servizi_ge.html
+++ b/templates/ordini_servizi_ge.html
@@ -5,7 +5,7 @@
             <!-- 1. Seleziona mese -->
             <div>
                 <label for="month-filter" class="form-label fw-bold visually-hidden">Mese Presentazione</label>
-                <select id="month-filter" class="form-select form-select-sm">
+                <select id="month-filter" class="form-select form-select-sm" data-dropup-auto="false">
                     <option value="" selected>Seleziona un mese...</option>
                 </select>
             </div>


### PR DESCRIPTION
## Summary
- keep month dropdown from turning into dropup
- force SelectPicker to drop down if loaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856d05686a48323aa0bc5a9a31283f9