### PR TITLE
Implement column visibility controls for Gestione GE

### DIFF
--- a/templates/ordini_servizi_ge.html
+++ b/templates/ordini_servizi_ge.html
@@ -38,7 +38,13 @@
                 <i class="fas fa-filter"></i> Filtri
             </button>
             <!-- 7. Visibilità colonne -->
-            <div id="dt-buttons-container"></div>
+            <div id="dt-buttons-container">
+                <div class="dt-buttons">
+                    <button id="btn-hide-all" class="btn btn-outline-secondary btn-sm">Nascondi tutto</button>
+                    <button id="btn-show-all" class="btn btn-outline-secondary btn-sm">Abilita tutto</button>
+                    <div id="column-buttons" class="btn-group ms-2"></div>
+                </div>
+            </div>
             <!-- 8. Esporta in Excel -->
             <button class="btn btn-sm btn-outline-success" id="exportBtn">
                 <i class="fas fa-file-excel me-1"></i> Esporta Excel


### PR DESCRIPTION
## Summary
- add `Nascondi tutto` and `Abilita tutto` controls in `ordini_servizi_ge.html`
- manage column visibility with new Tabulator helpers in `ordini_servizi_ge.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d049b6848323b4e4de1e0fa8b344