### PR TITLE
Switch to startswith year filter

### DIFF
--- a/ordini_materiale_articoli.py
+++ b/ordini_materiale_articoli.py
@@ -34,7 +34,7 @@ def _perform_search_query(
     """Esegue la query di ricerca con i filtri forniti."""
     query = db.query(Zucchetti_Articoli)
     if year and year.lower() != 'all':
-        query = query.filter(extract('year', Zucchetti_Articoli.DataAcquisto) == int(year))
+        query = query.filter(Zucchetti_Articoli.DataAcquisto.startswith(str(year)))
     if codice:
         query = query.filter(Zucchetti_Articoli.KACODRIC.ilike(f"%{codice}%"))
     if codicenet:

--- a/tests/test_perform_search_query.py
+++ b/tests/test_perform_search_query.py
@@ -1,5 +1,6 @@
 import pytest
 from ordini_materiale_articoli import _perform_search_query
+from models.zucchetti import Zucchetti_Articoli
 from unittest.mock import MagicMock
 
 class DummyQuery:
@@ -29,4 +30,5 @@ def test_perform_search_query_filters():
     # Test con tutti i filtri
     query = _perform_search_query(db, codice='A', codicenet='B', descrizione='C D', year='2023')
     # Dovrebbe aver aggiunto filtri per codice, codicenet, descrizione (2 parole), year
-    assert len(query.filters) == 5 
+    assert len(query.filters) == 5
+    assert str(query.filters[0][0][0]) == str(Zucchetti_Articoli.DataAcquisto.startswith('2023'))


### PR DESCRIPTION
## Summary
- filter materials by year with `startswith`
- test that query uses `startswith`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d63977f483238a11970128d227be