### PR TITLE
Refactor column visibility controls

### DIFF
--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -193,54 +193,44 @@ function applyVisibleColumnsState(table) {
 }
 
 function setupColumnVisibilityControls(table) {
-    const container = document.getElementById('column-buttons');
-    if (!container) return;
-    container.innerHTML = '';
+    const menu = document.getElementById('column-toggle-menu');
+    if (!menu) return;
+    menu.innerHTML = '';
 
     table.getColumns().forEach(col => {
         const field = col.getField();
         if (field === 'actions') return;
-        const btn = document.createElement('button');
-        btn.className = col.isVisible() ? 'btn btn-primary btn-sm' : 'btn btn-outline-secondary btn-sm';
-        btn.textContent = col.getDefinition().title;
-        btn.dataset.field = field;
-        btn.addEventListener('click', function () {
+        const li = document.createElement('li');
+        const div = document.createElement('div');
+        div.className = 'form-check';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'form-check-input';
+        checkbox.id = `toggle-col-${field}`;
+        checkbox.checked = col.isVisible();
+        checkbox.addEventListener('change', function () {
             const column = table.getColumn(field);
             if (!column) return;
-            if (column.isVisible()) {
-                column.hide();
-                this.className = 'btn btn-outline-secondary btn-sm';
-                visibleColumnsState = visibleColumnsState.filter(f => f !== field);
-            } else {
+            if (this.checked) {
                 column.show();
-                this.className = 'btn btn-primary btn-sm';
                 if (!visibleColumnsState.includes(field)) visibleColumnsState.push(field);
+            } else {
+                column.hide();
+                visibleColumnsState = visibleColumnsState.filter(f => f !== field);
             }
         });
         if (col.isVisible() && !visibleColumnsState.includes(field)) {
             visibleColumnsState.push(field);
         }
-        container.appendChild(btn);
+        const label = document.createElement('label');
+        label.className = 'form-check-label';
+        label.htmlFor = checkbox.id;
+        label.textContent = col.getDefinition().title;
+        div.appendChild(checkbox);
+        div.appendChild(label);
+        li.appendChild(div);
+        menu.appendChild(li);
     });
-
-    const btnHideAll = document.getElementById('btn-hide-all');
-    const btnShowAll = document.getElementById('btn-show-all');
-
-    if (btnHideAll) {
-        btnHideAll.addEventListener('click', () => {
-            table.getColumns().forEach(col => col.hide());
-            container.querySelectorAll('button').forEach(b => b.className = 'btn btn-outline-secondary btn-sm');
-            visibleColumnsState = [];
-        });
-    }
-
-    if (btnShowAll) {
-        btnShowAll.addEventListener('click', () => {
-            table.getColumns().forEach(col => col.show());
-            container.querySelectorAll('button').forEach(b => b.className = 'btn btn-primary btn-sm');
-            visibleColumnsState = table.getColumns().map(c => c.getField()).filter(f => f !== 'actions');
-        });
-    }
 }
 
 

--- a/templates/ordini_servizi_ge.html
+++ b/templates/ordini_servizi_ge.html
@@ -40,9 +40,12 @@
             <!-- 7. Visibilità colonne -->
             <div id="dt-buttons-container">
                 <div class="dt-buttons">
-                    <button id="btn-hide-all" class="btn btn-outline-secondary btn-sm">Nascondi tutto</button>
-                    <button id="btn-show-all" class="btn btn-outline-secondary btn-sm">Abilita tutto</button>
-                    <div id="column-buttons" class="btn-group ms-2"></div>
+                    <div class="dropdown">
+                        <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" id="column-toggle-dropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                            Colonne
+                        </button>
+                        <ul id="column-toggle-menu" class="dropdown-menu p-2" aria-labelledby="column-toggle-dropdown"></ul>
+                    </div>
                 </div>
             </div>
             <!-- 8. Esporta in Excel -->


### PR DESCRIPTION
## Summary
- remove global show/hide column buttons in ordini_servizi_ge table view
- add dropdown menu with checkboxes for column visibility
- update JavaScript to populate dropdown and handle visibility toggles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, sqlalchemy, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6856d63609948323bd65ccc1ff3f3a7c