### PR TITLE
Fix GE page layout

### DIFF
--- a/ordini_servizi.py
+++ b/ordini_servizi.py
@@ -208,7 +208,19 @@ async def ordini_servizi_page(request: Request):
 
 @router.get("/ordini_servizi/ge", include_in_schema=False)
 async def get_gestione_gs_tab(request: Request):
-    return templates.TemplateResponse("ordini_servizi_ge.html", {"request": request})
+    """Render the Gestione GS tab.
+
+    When called via AJAX the route returns only the tab content so it can be
+    injected into an existing page. If accessed directly it returns a complete
+    page extending ``base.html``.
+    """
+
+    is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
+    template = "ordini_servizi_ge_partial.html" if is_ajax else "ordini_servizi_ge.html"
+    context = {"request": request}
+    if not is_ajax:
+        context["username"] = request.cookies.get("session")
+    return templates.TemplateResponse(template, context)
 
 @router.get("/api/servizi/ge/columns")
 async def get_gestione_gs_columns(db: Session = Depends(get_db)):

--- a/static/js/ordini_servizi.js
+++ b/static/js/ordini_servizi.js
@@ -149,7 +149,9 @@
                 const tabName = this.dataset.tab;
                 console.log('Tab cliccato:', tabName);
                 // Caricamento dinamico per tutti i tab
-                fetch(`/ordini_servizi/${tabName}`)
+                fetch(`/ordini_servizi/${tabName}`, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                })
                     .then(response => {
                         if (!response.ok) throw new Error('Errore di rete');
                         return response.text();

--- a/templates/ordini_servizi_ge_partial.html
+++ b/templates/ordini_servizi_ge_partial.html
@@ -1,6 +1,3 @@
-{% extends 'base.html' %}
-
-{% block content %}
 <div class="container-fluid pt-3">
     <div id="main-controls-row" class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
         <!-- Left group: Custom Filters and DataTables Length/Buttons -->
@@ -64,7 +61,7 @@
 
     <!-- <div class="row mb-3">
         <div class="col-auto" id="colvis-container">
-             Il pulsante 'Visibilità Colonne' verrà spostato qui via JS
+             Il pulsante 'Visibilità Colonne' verrà spostato qui via JS 
         </div>
     </div> -->
 
@@ -89,7 +86,6 @@
     </div>
     <div class="advanced-filters-overlay"></div>
 </div>
-{% endblock %}
 
 {% block head_extra %}
 <link href="https://cdnjs.cloudflare.com/ajax/libs/tabulator/6.3.1/css/tabulator_bootstrap5.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- extend `ordini_servizi_ge.html` from `base.html`
- add Ajax-aware route logic to `/ordini_servizi/ge`
- send `X-Requested-With` header from JS when loading tabs
- keep original snippet as `ordini_servizi_ge_partial.html`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d634bf108323a3782cd700276a6d