### PR TITLE
Handle RTC filter data reload

### DIFF
--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -311,7 +311,14 @@ function setupColumnVisibilityControls(table) {
         }
         if (rtcFilter) {
             rtcFilter.disabled = true;
-            rtcFilter.addEventListener('change', loadOrUpdateTable);
+            rtcFilter.addEventListener('change', function () {
+                if (!tabulatorTable || !currentParams.month_filter) return;
+                currentParams.rtc_filter = this.value;
+                tabulatorTable.setData('/api/servizi/ge/data', {
+                    month_filter: currentParams.month_filter,
+                    rtc_filter: this.value
+                });
+            });
         }
         if (searchInput) {
             searchInput.addEventListener('keyup', function(e) {


### PR DESCRIPTION
## Summary
- register change event on `#rtc-filter`
- on change, reload table data with current month filter and new RTC value

## Testing
- `pytest -q` *(fails: DB_USER and DB_PASSWORD must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6857d1c7d00483239efb74e4c1714e80