### PR TITLE
Fix column resize persistence

### DIFF
--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -895,9 +895,10 @@ function enableColumnResize(tableSelector) {
             $('body').css('cursor', '');
             $(tableEl).removeClass('resizing-columns');
 
+            // Salva e ripristina le larghezze senza forzare DataTables
             saveColumnWidths(tableSelector);
             if (window.table) {
-                window.table.columns.adjust();
+                // window.table.columns.adjust(); // Evitato per mantenere la larghezza impostata
                 loadColumnWidths(tableSelector);
             }
         };


### PR DESCRIPTION
## Summary
- avoid DataTables adjust after manual column resize

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba1a930788323919cfc3dd983809d