### PR TITLE
Migliorata gestione autosize colonne

### DIFF
--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -931,7 +931,7 @@ function setColumnsAutosize(tableSelector, preventDraw = false) {
             window.table.columns.adjust().draw(false);
         }
     }
-    // loadColumnWidths(tableSelector); // NON va chiamato in autosize
+    loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate anche in autosize
 }
 
 function setColumnsFixedWrap(tableSelector, preventDraw = false) {
@@ -950,7 +950,7 @@ function setColumnsFixedWrap(tableSelector, preventDraw = false) {
             window.table.columns.adjust().draw(false);
         }
     }
-    loadColumnWidths(tableSelector); // Ripristina larghezze personalizzate SOLO in fixedwrap
+    loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate
 }
 
 function applyColumnViewMode(tableSelector, preventDraw = false) {

--- a/tests/test_set_columns_autosize.py
+++ b/tests/test_set_columns_autosize.py
@@ -1,0 +1,8 @@
+import re
+from pathlib import Path
+
+def test_set_columns_autosize_loads_widths():
+    js_path = Path(__file__).resolve().parents[1] / 'static' / 'js' / 'ordini_servizi_ge.js'
+    content = js_path.read_text(encoding='utf-8')
+    pattern = re.compile(r"function\s+setColumnsAutosize\([^)]*\)\s*\{[\s\S]*?loadColumnWidths\(", re.S)
+    assert pattern.search(content), "loadColumnWidths deve essere richiamato in setColumnsAutosize"


### PR DESCRIPTION
## Descrizione
- `setColumnsAutosize` ora richiama `loadColumnWidths` per ripristinare eventuali larghezze personalizzate.
- Aggiornati i commenti in `ordini_servizi_ge.js`.
- Aggiunto test `test_set_columns_autosize.py` per verificare la presenza della chiamata.

## Test
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba44f2bb88323aed2fa558dc605cb