### PR TITLE
Fix restore column widths only when saved

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SQLALCHEMY_DATABASE_URL_LOCAL=sqlite:///test.db

--- a/static/js/ordini_servizi_ge.js
+++ b/static/js/ordini_servizi_ge.js
@@ -931,7 +931,9 @@ function setColumnsAutosize(tableSelector, preventDraw = false) {
             window.table.columns.adjust().draw(false);
         }
     }
-    loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate anche in autosize
+    if (localStorage.getItem(COLUMN_WIDTHS_KEY)) {
+        loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate anche in autosize
+    }
 }
 
 function setColumnsFixedWrap(tableSelector, preventDraw = false) {
@@ -950,7 +952,9 @@ function setColumnsFixedWrap(tableSelector, preventDraw = false) {
             window.table.columns.adjust().draw(false);
         }
     }
-    loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate
+    if (localStorage.getItem(COLUMN_WIDTHS_KEY)) {
+        loadColumnWidths(tableSelector); // Ripristina eventuali larghezze personalizzate
+    }
 }
 
 function applyColumnViewMode(tableSelector, preventDraw = false) {

--- a/tests/test_set_columns_autosize.py
+++ b/tests/test_set_columns_autosize.py
@@ -6,3 +6,9 @@ def test_set_columns_autosize_loads_widths():
     content = js_path.read_text(encoding='utf-8')
     pattern = re.compile(r"function\s+setColumnsAutosize\([^)]*\)\s*\{[\s\S]*?loadColumnWidths\(", re.S)
     assert pattern.search(content), "loadColumnWidths deve essere richiamato in setColumnsAutosize"
+
+def test_set_columns_autosize_conditional_load():
+    js_path = Path(__file__).resolve().parents[1] / 'static' / 'js' / 'ordini_servizi_ge.js'
+    content = js_path.read_text(encoding='utf-8')
+    pattern = re.compile(r"function\s+setColumnsAutosize\([^)]*\)\s*\{[\s\S]*?if\s*\(\s*localStorage\.getItem\(COLUMN_WIDTHS_KEY\)\s*\)\s*\{[\s\S]*?loadColumnWidths\(", re.S)
+    assert pattern.search(content), "loadColumnWidths deve essere chiamato solo se esistono larghezze salvate"


### PR DESCRIPTION
## Summary
- aggiorna le funzioni di gestione larghezza colonne per verificare la presenza di impostazioni salvate
- estende i test su `setColumnsAutosize` per controllare la condizione sul `localStorage`
- aggiunge un file `.env` con una configurazione minima per far girare i test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685baa9204d4832386db69449c2ee6c6